### PR TITLE
fix: fix typo

### DIFF
--- a/SCD30.cpp
+++ b/SCD30.cpp
@@ -39,7 +39,7 @@ void SCD30::initialize(void) {
     
     Wire.begin(); // Added Wire begin to avoid infinite waiting
     setMeasurementInterval(2); // 2 seconds between measurements
-    startPeriodicMeasurment(); // start periodic measuments
+    startPeriodicMeasurement(); // start periodic measuments
 
     //setAutoSelfCalibration(true); // Enable auto-self-calibration
 }
@@ -65,7 +65,7 @@ void SCD30::setMeasurementInterval(uint16_t interval) {
     writeCommandWithArguments(SCD30_SET_MEASUREMENT_INTERVAL, interval);
 }
 
-void SCD30::startPeriodicMeasurment(void) {
+void SCD30::startPeriodicMeasurement(void) {
     writeCommandWithArguments(SCD30_CONTINUOUS_MEASUREMENT, 0x0000);
 }
 

--- a/SCD30.h
+++ b/SCD30.h
@@ -63,7 +63,7 @@ class SCD30 {
     void setAutoSelfCalibration(bool enable);
     void setMeasurementInterval(uint16_t interval);
 
-    void startPeriodicMeasurment(void);
+    void startPeriodicMeasurement(void);
     void stopMeasurement(void);
     void setTemperatureOffset(uint16_t offset);
 


### PR DESCRIPTION
`startPeriodicMeasurment` -> `startPeriodicMeasurement`